### PR TITLE
SQL-1118: Implement Odbc.Datasource SqlCapabilities and Extensible options

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -106,6 +106,9 @@ BuildOdbcConfig = () as record =>
     in
         Config;
 
+// ValidateOptions checks that the options are supported according to the validOptionsMap.
+// Returns a record of validated key/values.  
+// Function is from SqlODBC example.
 ValidateOptions = (options as nullable record, validOptionsMap as table) as record =>
     let
         ValidKeys = Table.Column(validOptionsMap, "Name"),

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -1,4 +1,4 @@
-﻿[Version = "0.0.0"]
+[Version = "0.0.0"]
 section MongoDBAtlasODBC;
 
 [DataSource.Kind="MongoDBAtlasODBC", Publish="MongoDBAtlasODBC.Publish"]
@@ -14,24 +14,32 @@ MongoDBAtlasODBCType = type function(
         Documentation.FieldCaption = "Database",
         Documentation.FieldDescription = "Database to connect to",
         Documentation.SampleValues = {"db"}
-    ]), 
+    ]),
     optional options as record)
     as table meta [
         Documentation.Name = "MongoDB Atlas SQL"
     ];
 
 MongoDBAtlasODBCImpl = (mongodbUri as text, database as text, optional options as record) as table => 
-let
-    Uri = ProcessUri(mongodbUri),
-    ConnectionString = [
-        Driver = "ADF_ODBC_DRIVER"
-    ],
-    CredentialConnectionString = GetCredentialConnectionString(),
-    OdbcDatasource = Odbc.DataSource(ConnectionString, [
-        // SQL-1118: Implement Odbc.Datasource SqlCapabilities and Extensible Options
-    ] & CredentialConnectionString)
-in
-    OdbcDatasource;
+    let
+        ValidOptionsMap = #table(
+            {"Name","Type","Description","Default","Validate"},
+            {
+                {"ApplicationName", type nullable text, "Enter a value to use as the Application Name in the SQL traces", null, each _ = null or _ <> null}
+            }
+        ),
+        ValidatedOptions = ValidateOptions(options, ValidOptionsMap),
+        Uri = ProcessUri(mongodbUri),
+        ConnectionString = [
+            APPLICATION_NAME = if ValidatedOptions[ApplicationName] <> null then ValidatedOptions[ApplicationName] else "MongoDB Atlas SQL - PowerBI",
+            DRIVER = "ADF_ODBC_DRIVER"
+        ],
+        CredentialConnectionString = GetCredentialConnectionString(),
+        Config = BuildOdbcConfig(),
+        OdbcDatasource = Odbc.DataSource(ConnectionString, Config
+            & [ CredentialConnectionString = CredentialConnectionString ])
+    in
+        OdbcDatasource;
 
 GetCredentialConnectionString = () as record =>
     let
@@ -73,3 +81,61 @@ MongoDBAtlasODBC.Icons = [
     Icon16 = { Extension.Contents("MongoDBAtlasODBC16.png"), Extension.Contents("MongoDBAtlasODBC20.png"), Extension.Contents("MongoDBAtlasODBC24.png"), Extension.Contents("MongoDBAtlasODBC32.png") },
     Icon32 = { Extension.Contents("MongoDBAtlasODBC32.png"), Extension.Contents("MongoDBAtlasODBC40.png"), Extension.Contents("MongoDBAtlasODBC48.png"), Extension.Contents("MongoDBAtlasODBC64.png") }
 ];
+
+BuildOdbcConfig = () as record =>
+    let
+        Config = [
+            SqlCapabilities = [
+                FractionalSecondsScale = 3,
+                LimitClauseKind = LimitClauseKind.LimitOffset,
+                SupportsDerivedTable = true,
+                SupportsNumericLiterals = true,
+                SupportsStringLiterals = true,
+                SupportsOdbcDateLiterals = true,
+                SupportsOdbcTimeLiterals = true,
+                SupportsOdbcTimestampLiterals = true
+            ],
+            SQLGetFunctions = [
+                SQL_API_SQLBINDPARAMETER = false,
+                SQL_CONVERT_FUNCTIONS = 0x2 /* SQL_FN_CVT_CAST */
+            ],
+            SQLGetInfo = [
+                SQL_SQL_CONFORMANCE = 8 /* SQL_SC_SQL92_FULL */
+            ]
+        ]
+    in
+        Config;
+
+ValidateOptions = (options as nullable record, validOptionsMap as table) as record =>
+    let
+        ValidKeys = Table.Column(validOptionsMap, "Name"),
+        InvalidKeys = List.Difference(Record.FieldNames(options), ValidKeys),
+        InvalidKeysText =
+            if List.IsEmpty(InvalidKeys) then
+                null
+            else
+                Text.Format(
+                    "'#{0}' are not valid options. Valid options are: '#{1}'",
+                    {Text.Combine(InvalidKeys, ", "), Text.Combine(ValidKeys, ", ")}
+                ),
+        ValidateValue = (name, optionType, description, default, validate, value) =>
+                if (value is null and (Type.IsNullable(optionType) or default <> null)) or (Type.Is(Value.Type(value), optionType) and validate(value)) then
+                    null
+                else
+                    Text.Format(
+                        "This function does not support the option '#{0}' with value '#{1}'. Valid value is #{2}.",
+                        {name, value, description}
+                    ),
+        InvalidValues = List.RemoveNulls(Table.TransformRows(validOptionsMap, each ValidateValue([Name],[Type],[Description],[Default],[Validate], Record.FieldOrDefault(options, [Name], [Default])))),
+        DefaultOptions = Record.FromTable(Table.RenameColumns(Table.SelectColumns(validOptionsMap,{"Name","Default"}),{"Default","Value"})),
+        NullNotAllowedFields = List.RemoveNulls(Table.TransformRows(validOptionsMap, each if not Type.IsNullable([Type]) and null = Record.FieldOrDefault(options, [Name], [Default]) then [Name] else null)),
+        NormalizedOptions = DefaultOptions & Record.RemoveFields(options, NullNotAllowedFields, MissingField.Ignore)
+    in
+        if null = options then 
+            DefaultOptions
+        else if not List.IsEmpty(InvalidKeys) then
+            error Error.Record("Expression.Error", InvalidKeysText)
+        else if not List.IsEmpty(InvalidValues) then
+            error Error.Record("Expression.Error", Text.Combine(InvalidValues, ", "))
+        else
+            NormalizedOptions;

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -142,4 +142,3 @@ ValidateOptions = (options as nullable record, validOptionsMap as table) as reco
             error Error.Record("Expression.Error", Text.Combine(InvalidValues, ", "))
         else
             NormalizedOptions;
-            

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -142,3 +142,4 @@ ValidateOptions = (options as nullable record, validOptionsMap as table) as reco
             error Error.Record("Expression.Error", Text.Combine(InvalidValues, ", "))
         else
             NormalizedOptions;
+            

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -1,5 +1,5 @@
-﻿// Use this file to write queries to test your data connector
+// Use this file to write queries to test your data connector
 let
-    result = MongoDBAtlasODBC.Contents()
+    result = MongoDBAtlasODBC.Contents("", "")
 in
     result


### PR DESCRIPTION
Capabilities and options are here: https://learn.microsoft.com/en-us/power-query/odbc-parameters

I only added values where the settings differed from the default, similar to the Tableau connector capabilities.  
For the options record that can be set, I included the `ApplicationName` as that can be set in the connection string.  Other options such as `ConnectionTimeout` I left out since we don't allow them to be set through the connection string.
