### PR TITLE
SQL-1117: Implement ProcessUri function

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -8,7 +8,7 @@ MongoDBAtlasODBCType = type function(
     mongodbUri as (type text meta[
         Documentation.FieldCaption = "MongoDB URI",
         Documentation.FieldDescription = "MongoDB connection URI",
-        Documentation.SampleValues = {"mongodb://hostname:port/admin"}
+        Documentation.SampleValues = {"mongodb://hostname:port/admin?ssl=true"}
     ]), 
     database as (type text meta [
         Documentation.FieldCaption = "Database",
@@ -37,7 +37,8 @@ MongoDBAtlasODBCImpl = (mongodbUri as text,
             {"Name","Type","Description","Default","Validate"},
             {
                 {
-                    "ApplicationName", type nullable text, 
+                    "APPLICATION_NAME", 
+                    type nullable text, 
                     "Enter a value to use as the Application Name in the SQL traces", 
                     null, 
                     each _ = null or _ <> null
@@ -65,65 +66,16 @@ GetCredentialConnectionString = () as record =>
     in
         CredentialConnectionString;
 
-NullFieldCheck = (field as any, fieldName as text ) =>
-    let 
-        Result = if field <> null then Record.AddField([], fieldName, field) else []
-    in
-        Result;
-
-ProcessAuthSrc = (queryEntry as any, pathEntry as any) =>
-    let
-        DefaultAuthSrc = "admin",
-        FieldName = "AUTH_SRC",
-        // The 'authSource' connection option takes precedence over the /defaultauthdb value in the connection string.
-        // If both are unspecified, then authSource defaults to 'admin'.
-        AuthSrc =    if queryEntry <> null then
-                        queryEntry
-                    else if pathEntry <> null and Text.Length(Text.Remove(pathEntry, "/")) > 0 then
-                        Text.Remove(pathEntry, "/")
-                    else
-                        DefaultAuthSrc,
-        Result = Record.AddField([], FieldName, AuthSrc)
-    in 
-        Result;
-
-ProcessUri = (uri as text) as any => 
-    let
-        DefaultPort = "27017",
-        UriParts = Uri.Parts(uri),
-        BadUri = UriParts[Host] = "" or UriParts[Fragment] <> ""
-            or UriParts[UserName] <> "" or UriParts[Password] <> "",
-        // http and https schemes automatically set port values to 80 and 443 respectively.
-        // The following checks whether the user has set the port values explicitly to 80 or 443.
-        // An unknown scheme will set the port value to -1 if it is not specified
-        Port =  if  (UriParts[Port] = 80 and not Text.Contains(uri, ":80")) or
-                    (UriParts[Port] = 443 and not Text.Contains(uri, ":443")) or
-                    UriParts[Port] = -1 then
-                    DefaultPort
-                else
-                    Number.ToText(UriParts[Port]),
-        SSL = NullFieldCheck(UriParts[Query][ssl]?, "SSL"),
-        TLS = NullFieldCheck(UriParts[Query][tls]?, "TLS"),
-        AuthSrc = ProcessAuthSrc(UriParts[Query][authSource]?, UriParts[Path]?),
-        Server = Text.Combine({UriParts[Host], ":", Port}),
-        Result =  Record.Combine({[ SERVER =  Server ], SSL, TLS, AuthSrc})
-    in 
-        if BadUri then 
-            error "Invalid URI"
-        else
-             Result;
-
 shared GetConnectionString = (uri as text, database as text, options as record) as record =>
     let 
-        Uri = ProcessUri(uri),
-        AppName = options[ApplicationName]?,
-        DatabaseNotSet = database = "",
+        AppName = options[APPLICATION_NAME]?,
+        DatabaseNotSet = (database = ""),
         ConnectionString = [
-            // SQL-1147: Connection string not accepting 'application_name'
-            // APPLICATION_NAME = if AppName <> null then AppName else "MongoDB Atlas SQL - PowerBI",
+            APPLICATION_NAME = if AppName <> null then AppName else "MongoDB Atlas SQL - PowerBI",
             DRIVER = "ADF_ODBC_DRIVER",
-            DATABASE = database
-        ] & Uri
+            DATABASE = database,
+            URI = uri
+        ] 
     in 
         if DatabaseNotSet then
             error "Database value cannot be empty"

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -29,15 +29,11 @@ MongoDBAtlasODBCImpl = (mongodbUri as text, database as text, optional options a
             }
         ),
         ValidatedOptions = ValidateOptions(options, ValidOptionsMap),
-        Uri = ProcessUri(mongodbUri),
-        ConnectionString = [
-            APPLICATION_NAME = if ValidatedOptions[ApplicationName] <> null then ValidatedOptions[ApplicationName] else "MongoDB Atlas SQL - PowerBI",
-            DRIVER = "ADF_ODBC_DRIVER"
-        ],
+        ConnectionString = GetConnectionString(mongodbUri, database, ValidatedOptions),
         CredentialConnectionString = GetCredentialConnectionString(),
         Config = BuildOdbcConfig(),
         OdbcDatasource = Odbc.DataSource(ConnectionString, Config
-            & [ CredentialConnectionString = CredentialConnectionString ])
+            & [ CredentialConnectionString = CredentialConnectionString])
     in
         OdbcDatasource;
 
@@ -51,12 +47,72 @@ GetCredentialConnectionString = () as record =>
     in
         CredentialConnectionString;
 
-// SQL-1117: Implement ProcessUri Function
-ProcessUri = (uri as text) as record => 
+NullFieldCheck = (field as any, fieldName as text ) =>
+    let 
+        EmptyRecord = [],
+        Result = if field <> null then Record.AddField(EmptyRecord, fieldName, field) else EmptyRecord
+    in
+        Result;
+
+ProcessAuthSrc = (queryEntry as any, pathEntry as any) =>
     let
-        Result = []
+        DefaultAuthSrc = "admin",
+        FieldName = "AUTH_SRC",
+        EmptyRecord = [],
+        // authSource connection option takes precedence over the defaultauthdb  value in the connection string.
+        // If both are unspecified, then authSource defaults to 'admin'.
+        AuthSrc =    if queryEntry <> null then
+                        queryEntry
+                    else if pathEntry <> null and Text.Length(Text.Remove(pathEntry, "/")) > 0 then
+                        Text.Remove(pathEntry, "/")
+                    else
+                        DefaultAuthSrc,
+        Result = Record.AddField(EmptyRecord, FieldName, AuthSrc)
     in 
         Result;
+
+ProcessUri = (uri as text) as any => 
+    let
+        DefaultPort = "27017",
+        UriParts = Uri.Parts(uri),
+        BadUri = UriParts[Host] = "" or UriParts[Fragment] <> ""
+            or UriParts[UserName] <> "" or UriParts[Password] <> "",
+        // http and https schemes automatically set port values to 80 and 443 respectively.
+        // The following checks whether the user has set the port values explicitly to 80 or 443.
+        // An unknown scheme will set the port value to -1 if it is not specified
+        Port =  if  (UriParts[Port] = 80 and not Text.Contains(uri, ":80")) or
+                    (UriParts[Port] = 443 and not Text.Contains(uri, ":443")) or
+                    UriParts[Port] = -1 then
+                    DefaultPort
+                else
+                    Number.ToText(UriParts[Port]),
+        SSL = NullFieldCheck(UriParts[Query][ssl]?, "SSL"),
+        TLS = NullFieldCheck(UriParts[Query][tls]?, "TLS"),
+        AuthSrc = ProcessAuthSrc(UriParts[Query][authSource]?, UriParts[Path]?),
+        Server = Text.Combine({UriParts[Host], ":", Port}),
+        Result =  Record.Combine({[ SERVER =  Server ], SSL, TLS, AuthSrc})
+    in 
+        if BadUri then 
+            error "Invalid URI"
+        else
+             Result;
+
+shared GetConnectionString = (uri as text, database as text, options as record) as record =>
+    let 
+        Uri = ProcessUri(uri),
+        AppName = options[ApplicationName]?,
+        DatabaseNotSet = database = "",
+        ConnectionString = [
+            // SQL-1147: Connection string not accepting 'application_name'
+            // APPLICATION_NAME = if AppName <> null then AppName else "MongoDB Atlas SQL - PowerBI",
+            DRIVER = "ADF_ODBC_DRIVER",
+            DATABASE = database
+        ] & Uri
+    in 
+        if DatabaseNotSet then
+            error "Database value cannot be empty"
+        else
+            ConnectionString;
 
 // Data Source Kind description
 MongoDBAtlasODBC = [
@@ -85,6 +141,7 @@ MongoDBAtlasODBC.Icons = [
 BuildOdbcConfig = () as record =>
     let
         Config = [
+            HierarchicalNavigation = true,
             SqlCapabilities = [
                 FractionalSecondsScale = 3,
                 LimitClauseKind = LimitClauseKind.LimitOffset,

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -33,7 +33,7 @@ MongoDBAtlasODBCImpl = (mongodbUri as text, database as text, optional options a
         CredentialConnectionString = GetCredentialConnectionString(),
         Config = BuildOdbcConfig(),
         OdbcDatasource = Odbc.DataSource(ConnectionString, Config
-            & [ CredentialConnectionString = CredentialConnectionString])
+            & [ CredentialConnectionString = CredentialConnectionString ])
     in
         OdbcDatasource;
 
@@ -49,8 +49,7 @@ GetCredentialConnectionString = () as record =>
 
 NullFieldCheck = (field as any, fieldName as text ) =>
     let 
-        EmptyRecord = [],
-        Result = if field <> null then Record.AddField(EmptyRecord, fieldName, field) else EmptyRecord
+        Result = if field <> null then Record.AddField([], fieldName, field) else []
     in
         Result;
 
@@ -58,7 +57,6 @@ ProcessAuthSrc = (queryEntry as any, pathEntry as any) =>
     let
         DefaultAuthSrc = "admin",
         FieldName = "AUTH_SRC",
-        EmptyRecord = [],
         // authSource connection option takes precedence over the defaultauthdb  value in the connection string.
         // If both are unspecified, then authSource defaults to 'admin'.
         AuthSrc =    if queryEntry <> null then
@@ -67,7 +65,7 @@ ProcessAuthSrc = (queryEntry as any, pathEntry as any) =>
                         Text.Remove(pathEntry, "/")
                     else
                         DefaultAuthSrc,
-        Result = Record.AddField(EmptyRecord, FieldName, AuthSrc)
+        Result = Record.AddField([], FieldName, AuthSrc)
     in 
         Result;
 

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -33,7 +33,7 @@ MongoDBAtlasODBCImpl = (mongodbUri as text,
                         optional options as record) 
                         as table => 
     let
-        ConnectionString = GetConnectionString(mongodbUri, database, []),
+        ConnectionString = GetConnectionString(mongodbUri, database),
         CredentialConnectionString = GetCredentialConnectionString(),
         Config = BuildOdbcConfig(),
         Result =    if query <> null then
@@ -53,7 +53,7 @@ GetCredentialConnectionString = () as record =>
     in
         CredentialConnectionString;
 
-shared GetConnectionString = (uri as text, database as text, options as record) as record =>
+shared GetConnectionString = (uri as text, database as text) as record =>
     let 
         DatabaseNotSet = (database = ""),
         ConnectionString = [

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -8,7 +8,7 @@ MongoDBAtlasODBCType = type function(
     mongodbUri as (type text meta[
         Documentation.FieldCaption = "MongoDB URI",
         Documentation.FieldDescription = "MongoDB connection URI",
-        Documentation.SampleValues = {"mongodb://hostname:port/admin?ssl=true"}
+        Documentation.SampleValues = {"mongodb://hostname:port/?ssl=true&authSource=admin"}
     ]), 
     database as (type text meta [
         Documentation.FieldCaption = "Database",

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -33,20 +33,7 @@ MongoDBAtlasODBCImpl = (mongodbUri as text,
                         optional options as record) 
                         as table => 
     let
-        ValidOptionsMap = #table(
-            {"Name","Type","Description","Default","Validate"},
-            {
-                {
-                    "APPLICATION_NAME", 
-                    type nullable text, 
-                    "Enter a value to use as the Application Name in the SQL traces", 
-                    null, 
-                    each _ = null or _ <> null
-                }
-            }
-        ),
-        ValidatedOptions = ValidateOptions(options, ValidOptionsMap),
-        ConnectionString = GetConnectionString(mongodbUri, database, ValidatedOptions),
+        ConnectionString = GetConnectionString(mongodbUri, database, []),
         CredentialConnectionString = GetCredentialConnectionString(),
         Config = BuildOdbcConfig(),
         Result =    if query <> null then
@@ -68,10 +55,8 @@ GetCredentialConnectionString = () as record =>
 
 shared GetConnectionString = (uri as text, database as text, options as record) as record =>
     let 
-        AppName = options[APPLICATION_NAME]?,
         DatabaseNotSet = (database = ""),
         ConnectionString = [
-            APPLICATION_NAME = if AppName <> null then AppName else "MongoDB Atlas SQL - PowerBI",
             DRIVER = "ADF_ODBC_DRIVER",
             DATABASE = database,
             URI = uri
@@ -130,40 +115,3 @@ BuildOdbcConfig = () as record =>
         ]
     in
         Config;
-
-// ValidateOptions checks that the options are supported according to the validOptionsMap.
-// Returns a record of validated key/values.  
-// Function is from SqlODBC example.
-ValidateOptions = (options as nullable record, validOptionsMap as table) as record =>
-    let
-        ValidKeys = Table.Column(validOptionsMap, "Name"),
-        InvalidKeys = List.Difference(Record.FieldNames(options), ValidKeys),
-        InvalidKeysText =
-            if List.IsEmpty(InvalidKeys) then
-                null
-            else
-                Text.Format(
-                    "'#{0}' are not valid options. Valid options are: '#{1}'",
-                    {Text.Combine(InvalidKeys, ", "), Text.Combine(ValidKeys, ", ")}
-                ),
-        ValidateValue = (name, optionType, description, default, validate, value) =>
-                if (value is null and (Type.IsNullable(optionType) or default <> null)) or (Type.Is(Value.Type(value), optionType) and validate(value)) then
-                    null
-                else
-                    Text.Format(
-                        "This function does not support the option '#{0}' with value '#{1}'. Valid value is #{2}.",
-                        {name, value, description}
-                    ),
-        InvalidValues = List.RemoveNulls(Table.TransformRows(validOptionsMap, each ValidateValue([Name],[Type],[Description],[Default],[Validate], Record.FieldOrDefault(options, [Name], [Default])))),
-        DefaultOptions = Record.FromTable(Table.RenameColumns(Table.SelectColumns(validOptionsMap,{"Name","Default"}),{"Default","Value"})),
-        NullNotAllowedFields = List.RemoveNulls(Table.TransformRows(validOptionsMap, each if not Type.IsNullable([Type]) and null = Record.FieldOrDefault(options, [Name], [Default]) then [Name] else null)),
-        NormalizedOptions = DefaultOptions & Record.RemoveFields(options, NullNotAllowedFields, MissingField.Ignore)
-    in
-        if null = options then 
-            DefaultOptions
-        else if not List.IsEmpty(InvalidKeys) then
-            error Error.Record("Expression.Error", InvalidKeysText)
-        else if not List.IsEmpty(InvalidValues) then
-            error Error.Record("Expression.Error", Text.Combine(InvalidValues, ", "))
-        else
-            NormalizedOptions;

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -25,7 +25,12 @@ MongoDBAtlasODBCImpl = (mongodbUri as text, database as text, optional options a
         ValidOptionsMap = #table(
             {"Name","Type","Description","Default","Validate"},
             {
-                {"ApplicationName", type nullable text, "Enter a value to use as the Application Name in the SQL traces", null, each _ = null or _ <> null}
+                {
+                    "ApplicationName", type nullable text, 
+                    "Enter a value to use as the Application Name in the SQL traces", 
+                    null, 
+                    each _ = null or _ <> null
+                }
             }
         ),
         ValidatedOptions = ValidateOptions(options, ValidOptionsMap),
@@ -57,7 +62,7 @@ ProcessAuthSrc = (queryEntry as any, pathEntry as any) =>
     let
         DefaultAuthSrc = "admin",
         FieldName = "AUTH_SRC",
-        // authSource connection option takes precedence over the defaultauthdb  value in the connection string.
+        // The 'authSource' connection option takes precedence over the /defaultauthdb value in the connection string.
         // If both are unspecified, then authSource defaults to 'admin'.
         AuthSrc =    if queryEntry <> null then
                         queryEntry

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -16,7 +16,7 @@ shared UnitTests =
           GetConnectionString("mongodb://localhost/pathauthsrc", "test", [])
         ),
         Fact("GetConnectionString - AuthSource option only",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test2", SERVER = "localhost:27017", AUTH_SRC = "optionauthsrc" ],
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "localhost:27017", AUTH_SRC = "optionauthsrc" ],
           GetConnectionString("mongodb://localhost/?authSource=optionauthsrc", "test", [])
         ),
         Fact("GetConnectionString - SSL option set",

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -1,5 +1,233 @@
-// Use this file to write queries to test your data connector
-let
-    result = MongoDBAtlasODBC.Contents("", "")
-in
-    result
+section MongoDBAtlasODBCUnitTests;
+shared UnitTests = 
+[
+    facts = 
+    {
+        Fact("GetConnectionString - Simple URI",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", SERVER = "localhost:27017", AUTH_SRC = "admin" ],
+          GetConnectionString("localhost", "db",  [])
+        ),
+        Fact("GetConnectionString - All options set",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db2", SERVER = "host.com:12345", SSL = "false",  TLS = "true", AUTH_SRC = "optionauthsrc" ],
+          GetConnectionString("mongodb+srv://host.com:12345/pathauthsrc?authSource=optionauthsrc&ssl=false&tls=true", "db2", [ ApplicationName = "{Testing AppName}"])
+        ),
+          Fact("GetConnectionString - AuthSource path only",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "localhost:27017", AUTH_SRC = "pathauthsrc" ],
+          GetConnectionString("mongodb://localhost/pathauthsrc", "test", [])
+        ),
+        Fact("GetConnectionString - AuthSource option only",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test2", SERVER = "localhost:27017", AUTH_SRC = "optionauthsrc" ],
+          GetConnectionString("mongodb://localhost/?authSource=optionauthsrc", "test", [])
+        ),
+        Fact("GetConnectionString - SSL option set",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "mongodb:27018", SSL = "true", AUTH_SRC = "admin" ],
+          GetConnectionString("mongodb:27018?ssl=true", "test",[])
+        ),
+        Fact("GetConnectionString - TLS option set",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "mongodb:27018", TLS = "false", AUTH_SRC = "admin" ],
+          GetConnectionString("mongodb:27018?tls=false", "test",[])
+        ),
+        Fact("GetConnectionString - Empty database value results in error",
+          "Database value cannot be empty",
+          try GetConnectionString("localhost","", [])  catch (e)  => e[Message]
+        ),
+        Fact("GetConnectionString - Empty host value results in error",
+          "Invalid URI: The hostname could not be parsed.",
+          try GetConnectionString("","db", [])  catch (e)  => e[Message]
+        ),
+        Fact("GetConnectionString - Username/Password in URI results in error",
+          "Invalid URI",
+          try GetConnectionString("mongodb://user:pass@localhost","db", []) catch (e)  => e[Message]
+        ), 
+        Fact("GetConnectionString - Fragment values in URI results in error",
+          "Invalid URI",
+          try GetConnectionString("mongodb://localhost/admin#fragment","db", [])  catch (e)  => e[Message]
+        )
+    },
+    report = Facts.Summarize(facts)
+][report];
+
+GetExpectedError = (function as any) as text =>
+  let
+    Error = try function
+            catch (e) => e[Message]
+  in
+    Error;
+
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        List.TransformAndCombine = (list, transform, separator) => Text.Combine(List.Transform(list, transform), separator),
+
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & List.TransformAndCombine(x, Serialize, ", ") & "} ",
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.TransformAndCombine(
+                                            Record.FieldNames(x), 
+                                            (item) => Serialize.Identifier(item) & " = " & Serialize(Record.Field(x, item)),
+                                            ", ") &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Identifier =  Expression.Identifier,
+
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.TransformAndCombine(
+                                                     Table.ToRecords(Table.Sort(schema,"Position")),
+                                                     each Serialize.Identifier(_[Name]) & " = " & _[Kind],
+                                                     ", ") &
+                                                 "] "),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.TransformAndCombine(
+                                                        Record.FieldNames(flds),
+                                                        (item) => Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]),
+                                                        ", ") & 
+                                                    (if Type.IsOpenRecord(x) then ", ..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.TransformAndCombine(
+                                        funsig,
+                                        (item)=>
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true),
+                                        ", ") &
+                                     ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is datetime     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is datetimezone then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is duration     then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
+                           if x is null         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
+                           if x is number       then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is time         then try Expression.Constant(x) otherwise "null /*serialize failed*/"     else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -10,6 +10,10 @@ shared UnitTests =
         Fact("GetConnectionString - Sets URI option",
           [ APPLICATION_NAME = "Test Application", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db_test", URI = "mongodb://localhost:27017/admin?ssl=false" ],
           GetConnectionString("mongodb://localhost:27017/admin?ssl=false", "db_test",  [ APPLICATION_NAME = "Test Application" ])
+        ),
+        Fact("GetConnectionString - Empty database value results in error",
+          "Database value cannot be empty",
+          try GetConnectionString("localhost","", [])  catch (e)  => e[Message]
         )
     },
     report = Facts.Summarize(facts)

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -3,13 +3,9 @@ shared UnitTests =
 [
     facts = 
     {
-        Fact("GetConnectionString - Sets URI option",
-          [ APPLICATION_NAME = "MongoDB Atlas SQL - PowerBI", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname/admin?ssl=true" ],
+        Fact("GetConnectionString - Set URI option",
+          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname/admin?ssl=true" ],
           GetConnectionString("mongodb://hostname/admin?ssl=true", "db",  [])
-        ),
-        Fact("GetConnectionString - Sets URI option",
-          [ APPLICATION_NAME = "Test Application", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db_test", URI = "mongodb://localhost:27017/admin?ssl=false" ],
-          GetConnectionString("mongodb://localhost:27017/admin?ssl=false", "db_test",  [ APPLICATION_NAME = "Test Application" ])
         ),
         Fact("GetConnectionString - Empty database value results in error",
           "Database value cannot be empty",

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -55,7 +55,7 @@ GetExpectedError = (function as any) as text =>
     Error;
 
 
-/// COMMON UNIT TESTING CODE 
+/// COMMON UNIT TESTING CODE - From DataConnectors/UnitTesting 
 Fact = (_subject as text, _expected, _actual) as record =>
 [   expected = try _expected,
     safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -5,11 +5,11 @@ shared UnitTests =
     {
         Fact("GetConnectionString - Set URI option",
           [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname/admin?ssl=true" ],
-          GetConnectionString("mongodb://hostname/admin?ssl=true", "db",  [])
+          GetConnectionString("mongodb://hostname/admin?ssl=true", "db")
         ),
         Fact("GetConnectionString - Empty database value results in error",
           "Database value cannot be empty",
-          try GetConnectionString("localhost","", [])  catch (e)  => e[Message]
+          try GetConnectionString("localhost","")  catch (e)  => e[Message]
         )
     },
     report = Facts.Summarize(facts)

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -4,12 +4,12 @@ shared UnitTests =
     facts = 
     {
         Fact("GetConnectionString - Sets URI option",
-          [ APPLICATION_NAME = "MongoDB Atlas SQL - PowerBI", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname:port/admin?ssl=true" ],
-          GetConnectionString("mongodb://hostname:port/admin?ssl=true", "db",  [])
+          [ APPLICATION_NAME = "MongoDB Atlas SQL - PowerBI", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname/admin?ssl=true" ],
+          GetConnectionString("mongodb://hostname/admin?ssl=true", "db",  [])
         ),
         Fact("GetConnectionString - Sets URI option",
-          [ APPLICATION_NAME = "Test Application", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db_test", URI = "mongodb://hostname:port/admin?ssl=true" ],
-          GetConnectionString("mongodb://hostname:port/admin?ssl=true", "db_test",  [ APPLICATION_NAME = "Test Application" ])
+          [ APPLICATION_NAME = "Test Application", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db_test", URI = "mongodb://localhost:27017/admin?ssl=false" ],
+          GetConnectionString("mongodb://localhost:27017/admin?ssl=false", "db_test",  [ APPLICATION_NAME = "Test Application" ])
         )
     },
     report = Facts.Summarize(facts)

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -3,45 +3,13 @@ shared UnitTests =
 [
     facts = 
     {
-        Fact("GetConnectionString - Simple URI",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", SERVER = "localhost:27017", AUTH_SRC = "admin" ],
-          GetConnectionString("localhost", "db",  [])
+        Fact("GetConnectionString - Sets URI option",
+          [ APPLICATION_NAME = "MongoDB Atlas SQL - PowerBI", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db", URI = "mongodb://hostname:port/admin?ssl=true" ],
+          GetConnectionString("mongodb://hostname:port/admin?ssl=true", "db",  [])
         ),
-        Fact("GetConnectionString - All options set",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db2", SERVER = "host.com:12345", SSL = "false",  TLS = "true", AUTH_SRC = "optionauthsrc" ],
-          GetConnectionString("mongodb+srv://host.com:12345/pathauthsrc?authSource=optionauthsrc&ssl=false&tls=true", "db2", [ ApplicationName = "{Testing AppName}"])
-        ),
-          Fact("GetConnectionString - AuthSource path only",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "localhost:27017", AUTH_SRC = "pathauthsrc" ],
-          GetConnectionString("mongodb://localhost/pathauthsrc", "test", [])
-        ),
-        Fact("GetConnectionString - AuthSource option only",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "localhost:27017", AUTH_SRC = "optionauthsrc" ],
-          GetConnectionString("mongodb://localhost/?authSource=optionauthsrc", "test", [])
-        ),
-        Fact("GetConnectionString - SSL option set",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "mongodb:27018", SSL = "true", AUTH_SRC = "admin" ],
-          GetConnectionString("mongodb:27018?ssl=true", "test",[])
-        ),
-        Fact("GetConnectionString - TLS option set",
-          [ DRIVER = "ADF_ODBC_DRIVER", DATABASE = "test", SERVER = "mongodb:27018", TLS = "false", AUTH_SRC = "admin" ],
-          GetConnectionString("mongodb:27018?tls=false", "test",[])
-        ),
-        Fact("GetConnectionString - Empty database value results in error",
-          "Database value cannot be empty",
-          try GetConnectionString("localhost","", [])  catch (e)  => e[Message]
-        ),
-        Fact("GetConnectionString - Empty host value results in error",
-          "Invalid URI: The hostname could not be parsed.",
-          try GetConnectionString("","db", [])  catch (e)  => e[Message]
-        ),
-        Fact("GetConnectionString - Username/Password in URI results in error",
-          "Invalid URI",
-          try GetConnectionString("mongodb://user:pass@localhost","db", []) catch (e)  => e[Message]
-        ), 
-        Fact("GetConnectionString - Fragment values in URI results in error",
-          "Invalid URI",
-          try GetConnectionString("mongodb://localhost/admin#fragment","db", [])  catch (e)  => e[Message]
+        Fact("GetConnectionString - Sets URI option",
+          [ APPLICATION_NAME = "Test Application", DRIVER = "ADF_ODBC_DRIVER", DATABASE = "db_test", URI = "mongodb://hostname:port/admin?ssl=true" ],
+          GetConnectionString("mongodb://hostname:port/admin?ssl=true", "db_test",  [ APPLICATION_NAME = "Test Application" ])
         )
     },
     report = Facts.Summarize(facts)

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -102,10 +102,10 @@ functions:
           ${prepare_shell}
           # Credential setting to be done with SQL-1124
           test_output=`tools/PQTest.exe run-test --extension MongoDBAtlasODBC.pqx --queryFile connector/MongoDBAtlasODBC.query.pq`
-          failures=`echo $test_output  | grep -Eo '"Result"[^}]*' | grep Failure`
+          failures=`echo $test_output  | grep -Eo '"Result"[^}]*' | grep Failure || true` 
           echo $test_output > MongoDBAtlasODBC.unit-test.log 
-
           if [[ ! -z $failures ]]; then 
+            echo "Failures Encountered:"
             echo $failures
             exit 1
           fi
@@ -169,7 +169,8 @@ pre:
   - func: "fetch source"
   - func: "generate expansions"
   - func: "install power query tools"
-post: []
+post: 
+  - func: "upload unit-test logs"
 
 tasks:
   - name: build
@@ -183,7 +184,6 @@ tasks:
     commands:
       - func: "fetch packaged connector"
       - func: "run unit-test"
-      - func: "upload unit-test logs"
 
   - name: sign
     depends_on:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -100,10 +100,15 @@ functions:
         working_dir: mongo-powerbi-connector
         script: |
           ${prepare_shell}
-          # Currently only runs unit test specified in queryFile
-          # Output checking and credential setting to be done with SQL-1124
+          # Credential setting to be done with SQL-1124
           test_output=`tools/PQTest.exe run-test --extension MongoDBAtlasODBC.pqx --queryFile connector/MongoDBAtlasODBC.query.pq`
-          echo $test_output > MongoDBAtlasODBC.unit-test.log
+          failures=`echo $test_output  | grep -Eo '"Result"[^}]*' | grep Failure`
+          echo $test_output > MongoDBAtlasODBC.unit-test.log 
+
+          if [[ ! -z $failures ]]; then 
+            echo $failures
+            exit 1
+          fi
 
   "sign connector":
     - command: shell.exec


### PR DESCRIPTION
Here's an example of what a unit test failure would look like ([link](https://evergreen.mongodb.com/task/mongo_powerbi_connector_windows_unit_test_patch_3a688e82b6085ef4502016e40e0823b5f9cf5f71_639911b2e3c331745f5d698f_22_12_13_23_58_57)): 
```
[2022/12/14 00:00:59.572] Failures Encountered:
[2022/12/14 00:00:59.572] "Result":"Failure ? ","Notes":"GetConnectionString - Simple URI","Details":" ([ DRIVER = \"aADF_ODBC_DRIVER\", DATABASE = \"db\", SERVER = \"localhost:27017\", AUTH_SRC = \"admin\" ] <> [ DRIVER = \"ADF_ODBC_DRIVER\", DATABASE = \"db\", SERVER = \"localhost:27017\", AUTH_SRC = \"admin\" ] )"
[2022/12/14 00:00:59.578] Command ''shell.exec' in "run unit-test"' failed: shell script encountered problem: exit code 1.
[2022/12/14 00:00:59.578] Task completed - FAILURE.
```