### PR TITLE
SQL-1120: implement TestConnection

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -69,6 +69,13 @@ shared GetConnectionString = (uri as text, database as text) as record =>
 
 // Data Source Kind description
 MongoDBAtlasODBC = [
+    TestConnection = (dataSourcePath) =>
+        let
+            json = Json.Document(dataSourcePath),
+            mongodbUri = json[mongodbUri],
+            database = json[database]
+        in
+            { "MongoDBAtlasODBC.Contents", mongodbUri, database },
     Authentication = [
         UsernamePassword = []
     ],


### PR DESCRIPTION
Adds TestConnection handler, which currently is used only for the on-premises data gateway to validate credentials. The handle typically just calls the main get data function, with only required arguments. In this case, we make a call to `MongoDBAtlastODBC.Contents`, with no query provided. 

Steps to test/reproduce (assuming a windows host with powerbi, mongo-odbc-driver is set up):
1. download the [on-prem data gateway (personal)](https://www.microsoft.com/en-us/download/details.aspx?id=55768)
2. open on-prem data gateway, then sign in. Once signed in, go to the `Connectors` tab and enable `Custom data connectors`. The filepath should match the same path used to locate mez files for Power BI Desktop (ie `C:\Users\<your username>\Documents\Power BI Desktop\Custom Connectors`). MongoDBAtlasODBC should populate this page if done properly.
3. start local adf using `run_adf.sh`. Open PowerBI Desktop, and create a report connecting to the local adf (example parameters: `uri: mongodb://localhost:27017/admin?ssl=false, db: integration_test, query: select _id, b from example`). At the moment, this should connect to data and preview it as binary. Before loading data, add a `Transform data` step that converts the column types into strings. (note: trying to load the binary directly yielded an invalid data type; this prevented publishing the dataset to powerbi, and thus testing the on-prem gateway). Once transform step is added, click close and apply.
4. save and publish report to powerbi
5. visit [Power BI Data Hub](https://app.powerbi.com/datahub). The dataset should now be visible. Hover over, then use the `...` to go to `settings`. Expand `Data Source Credentials` and choose `edit credentials`. Use this prompt to add the username and password for your local adf. Finish by clicking `Sign In`.
6. Return to the data hub, and now refresh the dataset. This should then result in an updated timestamp under `refreshed`. If so, the on-premises data gateway (and TestConnection handler) are working properly.

