### PR TITLE
SQL-1144: Implement AstVisitor option

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -93,7 +93,19 @@ MongoDBAtlasODBC.Icons = [
 
 BuildOdbcConfig = () as record =>
     let
+        AstVisitor = [
+            LimitClause = (skip, take) =>
+        let
+            offset = if (skip > 0) then Text.Format("OFFSET #{0}", {skip}) else "",
+            limit = if (take <> null) then Text.Format("LIMIT #{0}", {take}) else ""
+        in
+            [
+                Text = Text.Format("#{0} #{1}", {offset, limit}),
+                Location = "AfterQuerySpecification"
+            ]
+        ],
         Config = [
+            AstVisitor = AstVisitor,
             HierarchicalNavigation = true,
             SqlCapabilities = [
                 FractionalSecondsScale = 3,

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -94,15 +94,16 @@ MongoDBAtlasODBC.Icons = [
 BuildOdbcConfig = () as record =>
     let
         AstVisitor = [
+            // Specifying the supported LIMIT OFFSET format
             LimitClause = (skip, take) =>
-        let
-            offset = if (skip > 0) then Text.Format("OFFSET #{0}", {skip}) else "",
-            limit = if (take <> null) then Text.Format("LIMIT #{0}", {take}) else ""
-        in
-            [
-                Text = Text.Format("#{0} #{1}", {offset, limit}),
-                Location = "AfterQuerySpecification"
-            ]
+                let
+                    offset = if (skip > 0) then Text.Format("OFFSET #{0}", {skip}) else "",
+                    limit = if (take <> null) then Text.Format("LIMIT #{0}", {take}) else ""
+                in
+                    [
+                        Text = Text.Format("#{0} #{1}", {offset, limit}),
+                        Location = "AfterQuerySpecification"
+                    ]
         ],
         Config = [
             AstVisitor = AstVisitor,


### PR DESCRIPTION
Added an override to LimitClause to specify the supported format.  Verified the generated query adds `LIMIT` at end of query.

As for the additional changes I had planned with regards to the `CAST`, it turns out that the `Constant` value being overridden has been "deprecated and may be removed from future implementations" ([link](https://learn.microsoft.com/en-us/power-query/odbc-parameters#constant)).  That limits what we can do here.  I tested in import mode querying and transforming data and it's possible it isn't a problem for import since it mainly does `select [column list] from table` queries, but would pose an problem for DirectQuery mode.