### PR TITLE
SQL-1121: Convert SQL_UNKNOWN_TYPEs from binary to text on data load

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -71,25 +71,9 @@ shared TransformSqlUnknownColumns = (table) =>
     let
         TableType = Value.Type(table),
         Schema = Table.Schema(table),                        
-        SqlUnknownColumns = Table.ToRecords(Table.SelectRows(Schema, 
-            each [NativeTypeName] = "array"
-            or [NativeTypeName] = "dbPointer"
-            or [NativeTypeName] = "decimal"
-            or [NativeTypeName] = "javascript"
-            or [NativeTypeName] = "javascriptWithScope"
-            or [NativeTypeName] = "maxKey" 
-            or [NativeTypeName] = "minKey"
-            or [NativeTypeName] = "null"
-            or [NativeTypeName] = "object"
-            or [NativeTypeName] = "objectId"
-            or [NativeTypeName] = "regex"
-            or [NativeTypeName] = "symbol"
-            or [NativeTypeName] = "timestamp" 
-            or [NativeTypeName] = "undefined"
-            )),
-        TransformOperations = List.Accumulate(SqlUnknownColumns, table, (state, column) =>
+        SqlBinaryTypes = Table.ToRecords(Table.SelectRows(Schema,  each [TypeName] = "Binary.Type" and [NativeTypeName] <> "binData")),
+        TransformOperations = List.Accumulate(SqlBinaryTypes, table, (state, column) =>
             let
-                ColumnType = Type.TableColumn(TableType, column[Name]),
                 TransformColumn = Table.TransformColumns(state, { column[Name], Text.FromBinary })
             in
                 TransformColumn)

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -69,7 +69,6 @@ GetCredentialConnectionString = () as record =>
 // Transforms the columns that the driver specifies as SQL_UNKNOWN_TYPE from binary to text values
 shared TransformSqlUnknownColumns = (table) => 
     let
-        TableType = Value.Type(table),
         Schema = Table.Schema(table),                        
         SqlBinaryTypes = Table.ToRecords(Table.SelectRows(Schema,  each [TypeName] = "Binary.Type" and [NativeTypeName] <> "binData")),
         TransformOperations = List.Accumulate(SqlBinaryTypes, table, (state, column) =>

--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -36,12 +36,25 @@ MongoDBAtlasODBCImpl = (mongodbUri as text,
         ConnectionString = GetConnectionString(mongodbUri, database),
         CredentialConnectionString = GetCredentialConnectionString(),
         Config = BuildOdbcConfig(),
-        Result =    if query <> null then
+        DataSource =    if query <> null then
                         Odbc.Query(ConnectionString, query,  [ CredentialConnectionString = CredentialConnectionString ])
                     else
-                        Odbc.DataSource(ConnectionString, Config & [ CredentialConnectionString = CredentialConnectionString ])
+                        Odbc.DataSource(ConnectionString, Config & [ CredentialConnectionString = CredentialConnectionString ]),
+        
+        Metadata = Value.Metadata(Value.Type(DataSource)),
+        TransformColumns = 
+            let
+                TransformColumns =  if query <> null then 
+                                        TransformSqlUnknownColumns(DataSource)
+                                    else
+                                        TransformColumnKeepType(DataSource, "Data", 
+                                            (tables) => TransformColumnKeepType(tables, "Data",
+                                                TransformSqlUnknownColumns))
+            in
+                TransformColumns,
+        WithMetadata = Value.ReplaceType(TransformColumns, Value.ReplaceMetadata(Value.Type(DataSource), Metadata))
     in
-        Result;
+        WithMetadata;
 
 GetCredentialConnectionString = () as record =>
     let
@@ -52,6 +65,45 @@ GetCredentialConnectionString = () as record =>
         ]
     in
         CredentialConnectionString;
+
+// Transforms the columns that the driver specifies as SQL_UNKNOWN_TYPE from binary to text values
+shared TransformSqlUnknownColumns = (table) => 
+    let
+        TableType = Value.Type(table),
+        Schema = Table.Schema(table),                        
+        SqlUnknownColumns = Table.ToRecords(Table.SelectRows(Schema, 
+            each [NativeTypeName] = "array"
+            or [NativeTypeName] = "dbPointer"
+            or [NativeTypeName] = "decimal"
+            or [NativeTypeName] = "javascript"
+            or [NativeTypeName] = "javascriptWithScope"
+            or [NativeTypeName] = "maxKey" 
+            or [NativeTypeName] = "minKey"
+            or [NativeTypeName] = "null"
+            or [NativeTypeName] = "object"
+            or [NativeTypeName] = "objectId"
+            or [NativeTypeName] = "regex"
+            or [NativeTypeName] = "symbol"
+            or [NativeTypeName] = "timestamp" 
+            or [NativeTypeName] = "undefined"
+            )),
+        TransformOperations = List.Accumulate(SqlUnknownColumns, table, (state, column) =>
+            let
+                ColumnType = Type.TableColumn(TableType, column[Name]),
+                TransformColumn = Table.TransformColumns(state, { column[Name], Text.FromBinary })
+            in
+                TransformColumn)
+    in
+        TransformOperations;
+
+// Executes operation on specified columnName of the passed in table
+shared TransformColumnKeepType = (table, columnName, operation) =>
+    let
+        TableType = Value.Type(table),
+        TransformColumn = Table.TransformColumns(table, { columnName, operation}),
+        ReplaceType = Value.ReplaceType(TransformColumn, TableType)
+    in
+        ReplaceType;
 
 shared GetConnectionString = (uri as text, database as text) as record =>
     let 

--- a/connector/MongoDBAtlasODBC.query.pq
+++ b/connector/MongoDBAtlasODBC.query.pq
@@ -10,10 +10,73 @@ shared UnitTests =
         Fact("GetConnectionString - Empty database value results in error",
           "Database value cannot be empty",
           try GetConnectionString("localhost","")  catch (e)  => e[Message]
+        ),
+        Fact("TransformColumnKeepType - Transform columns of table in 'Transform' column",
+          { #table( type table [Array = text, Binary = binary] , {} )},
+          TransformColumnKeepType(GetDatabaseWithBsonTable(), "Transform", TransformSqlUnknownColumns)[Transform]
+        ),
+        Fact("TransformSqlUnknownColumns - SQL_UNKNOWN_TYPE columns transform to Text.Type",
+          { "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Text.Type", 
+            "Date.Type", 
+            "Number.Type", 
+            "Logical.Type", 
+            "Binary.Type"},
+           Table.Schema(TransformSqlUnknownColumns(GetTableWithBsonTypes()))[TypeName]
+
         )
     },
     report = Facts.Summarize(facts)
 ][report];
+
+GetTableWithBsonTypes = () as table =>
+let
+  Type = type table [
+    Array = (Type.ReplaceFacets(type binary, [NativeTypeName = "array"] )),
+    DbPointer = (Type.ReplaceFacets(type binary, [NativeTypeName = "dbPointer"] )),
+    Decimal = (Type.ReplaceFacets(type binary, [NativeTypeName = "decimal"] )),
+    Javascript = (Type.ReplaceFacets(type binary, [NativeTypeName = "javascript"] )),
+    JavascriptWithScope = (Type.ReplaceFacets(type binary, [NativeTypeName = "javascriptWithScope"] )),
+    MaxKey = (Type.ReplaceFacets(type binary, [NativeTypeName = "maxKey"] )),
+    MinKey = (Type.ReplaceFacets(type binary, [NativeTypeName = "minKey"] )),
+    Null = (Type.ReplaceFacets(type binary, [NativeTypeName = "null"] )),
+    Object = (Type.ReplaceFacets(type binary, [NativeTypeName = "object"] )),
+    ObjectId = (Type.ReplaceFacets(type binary, [NativeTypeName = "objectId"] )),
+    Regex = (Type.ReplaceFacets(type binary, [NativeTypeName = "regex"] )),
+    Symbol = (Type.ReplaceFacets(type binary, [NativeTypeName = "symbol"] )),
+    TimeStamp = (Type.ReplaceFacets(type binary, [NativeTypeName = "timestamp"] )),
+    Undefined = (Type.ReplaceFacets(type binary, [NativeTypeName = "undefined"] )),
+    Date = (Type.ReplaceFacets(type date, [NativeTypeName = "date"] )),
+    Number = (Type.ReplaceFacets(type number, [NativeTypeName = "int"] )),
+    Logical = (Type.ReplaceFacets(type logical, [NativeTypeName = "bool"] )),
+    Binary = (Type.ReplaceFacets(type binary, [NativeTypeName = "binData"] ))
+  ],
+  Table = #table(Type, {})
+in
+ Table;
+
+GetDatabaseWithBsonTable = () as table =>
+    let
+        Type = type table [
+            Array = (Type.ReplaceFacets(type binary, [NativeTypeName = "array"] )),
+            Binary = (Type.ReplaceFacets(type binary, [NativeTypeName = "binData"] ))
+        ],
+        Table = #table(Type, {}),
+        Database = #table({"Transform"},{{Table}})
+    in
+        Database;
 
 GetExpectedError = (function as any) as text =>
   let
@@ -21,7 +84,6 @@ GetExpectedError = (function as any) as text =>
             catch (e) => e[Message]
   in
     Error;
-
 
 /// COMMON UNIT TESTING CODE - From DataConnectors/UnitTesting 
 Fact = (_subject as text, _expected, _actual) as record =>


### PR DESCRIPTION
Transforms the types that we report as UNKNOWN_TYPE to text using [Text.FromBinary ](https://learn.microsoft.com/en-us/powerquery-m/text-frombinary).

Works for table listing and native query.

This latest code so far has not been seeing the slowness that I reported yesterday.  Running native query does not have slowness as it does not iterate through the database to run the TransformColumns.  Try it out and let me know if it is slow when showing the navigation table.