### PR TITLE
SQL-1311: Add steps tp upload mez file

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -260,6 +260,7 @@ functions:
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
+        display_name: MongoDBAtlasODBC.mez
 
   "upload release":
     - command: s3.put
@@ -288,6 +289,7 @@ functions:
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
+        display_name: MongoDBAtlasODBC-${RELEASE_VERSION}.mez
 
   "upload signed connector":
     - command: s3.put

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -251,6 +251,15 @@ functions:
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-powerbi-connector/connector/bin/AnyCPU/Debug/connector.mez
+        remote_file: mongo-powerbi-connector/artifacts/${version_id}/${build_variant}/MongoDBAtlasODBC.mez
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/octet-stream
 
   "upload release":
     - command: s3.put
@@ -262,6 +271,22 @@ functions:
         bucket: translators-connectors-releases
         permissions: public-read
         display_name: MongoDBAtlasODBC-${RELEASE_VERSION}.pqx
+        content_type: application/octet-stream
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongo-powerbi-connector/artifacts/${version_id}/${build_variant}/MongoDBAtlasODBC.mez
+        local_file: mongo-powerbi-connector/MongoDBAtlasODBC.mez
+        bucket: mciuploads
+    - command: s3.put
+      params:
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
+        local_file: mongo-powerbi-connector/MongoDBAtlasODBC.mez
+        remote_file: mongo-powerbi-connector/MongoDBAtlasODBC-${RELEASE_VERSION}.mez
+        bucket: translators-connectors-releases
+        permissions: public-read
         content_type: application/octet-stream
 
   "upload signed connector":


### PR DESCRIPTION
MSFT requires to upload the mez file from their UI.
Adding the steps to upload it in our release bucket along with the pqx.

I ran the build and release tasks on a patch (commenting out `git_tag_only: true` on the release task)
Here is the link for the run : https://spruce.mongodb.com/version/6419ec262a60ed80b3d9d5c9/tasks
The mez file was uploaded from the build task here : https://mciuploads.s3.amazonaws.com/mongo-powerbi-connector/artifacts/6419ec262a60ed80b3d9d5c9/windows-64/MongoDBAtlasODBC.mez
And uploaded from the release task here : https://translators-connectors-releases.s3.amazonaws.com/mongo-powerbi-connector/MongoDBAtlasODBC-0.0.0-v0.1.1-1-gc041662.mez