### PR TITLE
tell the driver to return simple types

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -59,7 +59,8 @@ GetConnectionString = (uri as text, database as text) as record =>
             DRIVER = "MongoDB Atlas SQL ODBC Driver",
             DATABASE = database,
             URI = uri,
-            APPNAME = "powerbi-connector+<connector-version>"
+            APPNAME = "powerbi-connector+<connector-version>",
+            SIMPLE_TYPES_ONLY = 1
         ]
     in
         if DatabaseNotSet then


### PR DESCRIPTION
I actually missed this when testing out native query because I was flattening and unwinding tables! This will make it so binary isn't displayed for our rich datatypes