### PR TITLE
SQL-1780: Add pq file for Merge Queries

### DIFF
--- a/resources/direct_query/merge_queries.pq
+++ b/resources/direct_query/merge_queries.pq
@@ -1,0 +1,27 @@
+let
+    Source = MongoDBAtlasODBC.Contents("mongodb://localhost", "reports", []),
+    reports_Database = Source{[Name="reports",Kind="Database"]}[Data],
+    table_ops_Table = reports_Database{[Name="table_ops",Kind="Table"]}[Data],
+    m = Table.NestedJoin(table_ops_Table, {"int0"}, table_ops_Table, {"int1"}, "table_ops2", JoinKind.Inner),
+    ret = Table.ExpandTableColumn(m, "table_ops2",
+      {
+            "_id",
+            "bool0",
+            "str0",
+            "int0",
+            "int1",
+            "int2",
+            "num0"
+      },
+      {
+            "t._id",
+            "t.bool0",
+            "t.str0",
+            "t.int0",
+            "t.int1",
+            "t.int2",
+            "t.num0"
+      }
+    )
+in
+    ret


### PR DESCRIPTION
This will correctly produce the following query in Power BI:
```
select `OTBL`.`_id`,
    `OTBL`.`bool0`,
    `OTBL`.`int0`,
    `OTBL`.`int1`,
    `OTBL`.`int2`,
    `OTBL`.`num0`,
    `OTBL`.`str0`,
    `ITBL`.`_id` as `t._id`,
    `ITBL`.`bool0` as `t.bool0`,
    `ITBL`.`str0` as `t.str0`,
    `ITBL`.`int0` as `t.int0`,
    `ITBL`.`int1` as `t.int1`,
    `ITBL`.`int2` as `t.int2`,
    `ITBL`.`num0` as `t.num0`
from `reports`.`table_ops` as `OTBL`
inner join `reports`.`table_ops` as `ITBL` on (`OTBL`.`int0` = `ITBL`.`int1`)
```

As can be verified by selecting "View Native Query" on the "ret" step.