### PR TITLE
SQL-1754: Add group report

### DIFF
--- a/resources/direct_query/group.pq
+++ b/resources/direct_query/group.pq
@@ -1,0 +1,7 @@
+let
+    Source = MongoDBAtlasODBC.Contents("mongodb://localhost", "reports", []),
+    reports_Database = Source{[Name="reports",Kind="Database"]}[Data],
+    table_ops_Table = reports_Database{[Name="table_ops",Kind="Table"]}[Data],
+    ret = Table.Group(table_ops_Table, {"str0", "bool0"}, {{"Count", each Table.RowCount(_), Int64.Type}, {"Sum", each List.Sum([int0]), type number}, {"Avg", each List.Average([num0]), type number}, {"Min", each List.Min([int1]), type number}, {"Max", each List.Max([int2]), type number}, {"All", each _, type table [_id=number, bool0=logical, int0=number, int1=number, int2=number, num0=number, str0=text]}})
+in
+    ret

--- a/resources/direct_query/group.pq
+++ b/resources/direct_query/group.pq
@@ -2,6 +2,6 @@ let
     Source = MongoDBAtlasODBC.Contents("mongodb://localhost", "reports", []),
     reports_Database = Source{[Name="reports",Kind="Database"]}[Data],
     table_ops_Table = reports_Database{[Name="table_ops",Kind="Table"]}[Data],
-    ret = Table.Group(table_ops_Table, {"str0", "bool0"}, {{"Count", each Table.RowCount(_), Int64.Type}, {"Sum", each List.Sum([int0]), type number}, {"Avg", each List.Average([num0]), type number}, {"Min", each List.Min([int1]), type number}, {"Max", each List.Max([int2]), type number}, {"All", each _, type table [_id=number, bool0=logical, int0=number, int1=number, int2=number, num0=number, str0=text]}})
+    ret = Table.Group(table_ops_Table, {"str0", "bool0"}, {{"Count", each Table.RowCount(_), Int64.Type}, {"Sum", each List.Sum([int0]), type number}, {"Avg", each List.Average([num0]), type number}, {"Min", each List.Min([int1]), type number}, {"Max", each List.Max([int2]), type number}})
 in
     ret


### PR DESCRIPTION
This handles all the group operations, it generates the following "native query":

```
select `str0`,
    `bool0`,
    count(1) as `Count`,
    sum(cast(`int0` as double)) as `Sum`,
    avg(`num0`) as `Avg`,
    min(`int1`) as `Min`,
    max(`int2`) as `Max`
from `reports`.`table_ops`
group by `str0`,
    `bool0`
```