### PR TITLE
SQL-1757: Add type conversion query

### DIFF
--- a/resources/direct_query/conversion.pq
+++ b/resources/direct_query/conversion.pq
@@ -1,0 +1,23 @@
+let
+    Source = MongoDBAtlasODBC.Contents("mongodb://localhost", "reports", []),
+    reports_Database = Source{[Name="reports",Kind="Database"]}[Data],
+    transforms_Table = reports_Database{[Name="transforms",Kind="Table"]}[Data],
+    #"Changed Type" = Table.TransformColumnTypes(transforms_Table,{
+        {"bool0", Int64.Type},
+        {"bool1", type text},
+        {"bool2", type logical},
+        {"int0", Int64.Type},
+        {"int1", type text},
+        {"int2", type logical},
+        {"int3", type datetime},
+        {"num0", Int64.Type},
+        {"num1", type text},
+        {"num2", type logical},
+        {"date0", type datetime},
+        {"date1", type text},
+        {"str1", type logical},
+        {"str2", type text},
+        {"str3", Int64.Type}
+    })
+in
+    #"Changed Type"


### PR DESCRIPTION
This generates the following "native query":

```
select `_id`,
    `array`,
    `binary`,
    cast(`bool0` as long) as `bool0`,
    case
        when `bool1` = 1
        then 'true'
        else 'false'
    end as `bool1`,
    `bool2` as `bool2`,
    `date0` as `date0`,
    cast(`date1` as varchar) as `date1`,
    `date10`,
    `date11`,
    `date12`,
    `date13`,
    `date14`,
    `date15`,
    `date16`,
    `date17`,
    `date18`,
    `date19`,
    `date2`,
    `date20`,
    `date21`,
    `date22`,
    `date3`,
    `date4`,
    `date5`,
    `date6`,
    `date7`,
    `date8`,
    `date9`,
    `dbPointer`,
    `decimal128`,
    cast(`int0` as long) as `int0`,
    cast(`int1` as varchar) as `int1`,
    case
        when `int2` <> 0
        then 1
        else 0
    end as `int2`,
    { fn timestampadd(SQL_TSI_FRAC_SECOND, (({ fn abs(`int3`) } - { fn floor({ fn abs(`int3`) }) }) + (case
        when `int3` < 0 and { fn abs(`int3`) } - { fn floor({ fn abs(`int3`) }) } <> 0
        then 1
        else 0
    end)) * 8.640000000000000E+007, { fn timestampadd(SQL_TSI_DAY, { fn floor(`int3`) }, {ts '1899-12-30 00:00:00'}) }) } as `int3`,
    `javascript`,
    `javascriptWithScope`,
    `maxKey`,
    `minKey`,
    `null`,
    cast({ fn round(`num0`, 0) } as long) as `num0`,
    cast(`num1` as varchar) as `num1`,
    case
        when `num2` <> 0.000000000000000E+000
        then 1
        else 0
    end as `num2`,
    `num3`,
    `num4`,
    `num5`,
    `num6`,
    `num7`,
    `num8`,
    `object`,
    `objectId`,
    `regex`,
    `str0`,
    case
        when `str1` = 'true'
        then 1
        else 0
    end as `str1`,
    `str2` as `str2`,
    cast({ fn round(cast(`str3` as double), 0) } as long) as `str3`,
    `str4`,
    `symbol`,
    `timestamp`
from `reports`.`transforms`
```