### PR TITLE
remove double datasource.kind decl

### DIFF
--- a/connector/MongoDBAtlasODBC.pq
+++ b/connector/MongoDBAtlasODBC.pq
@@ -12,7 +12,6 @@ AtlasSQLLink = "https://www.mongodb.com/atlas/sql";
 [DataSource.Kind = "MongoDBAtlasODBC", Publish = "MongoDBAtlasODBC.Publish"]
 shared MongoDBAtlasODBC.Contents = Value.ReplaceType(MongoDBAtlasODBCImpl, MongoDBAtlasODBCType);
 
-[DataSource.Kind = "MongoDBAtlasODBC"]
 shared MongoDBAtlasODBC.Query = (mongoDbUri, database, query, optional options) =>
     error
         Error.Record(


### PR DESCRIPTION
The double declaration of DataSource.Kind actually causes issues. Now that I'm not shadowing thanks to changes in the way MSFT loaded the custom connectors, I've verified this works and produces the desired error message for `.Query()`