### PR TITLE
SQL-2299: Use github token for cloning instead of ssh

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -97,6 +97,13 @@ functions:
       params:
         file: mongo-powerbi-connector/expansions.yml
 
+  "generate github token":
+    command: github.generate_token
+    params:
+      owner: 10gen
+      repo: mongohouse
+      expansion_name: github_token
+
   "install mongoimport tool":
     - command: shell.exec
       params:
@@ -125,6 +132,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          GITHUB_TOKEN: "${github_token}"
         add_expansions_to_env: true
         shell: bash
         working_dir: mongo-powerbi-connector
@@ -355,6 +364,7 @@ tasks:
       - name: build
     commands:
       - func: "install mongoimport tool"
+      - func: "generate github token"
       - func: "run integration test"
 
   - name: sign

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -150,9 +150,7 @@ functions:
           ./mongoimport.exe --uri="mongodb://$ADF_TEST_LOCAL_HOST:$MDB_TEST_LOCAL_PORT/integration_test" \
             --drop resources/integration_test/testdata/complex_types.json &&
 
-
-          MONGOSHELL=$(find ./local_adf/ | grep mongo.exe | head -1) &&
-          chmod +x $MONGOSHELL &&
+          MONGOSHELL=$(find ./local_adf/ | grep mongosh.exe | head -1) &&
 
           # Generate schema on imported data
           $MONGOSHELL -u $ADF_TEST_LOCAL_USER --password $ADF_TEST_LOCAL_PWD --authenticationDatabase \
@@ -172,21 +170,20 @@ functions:
           # Run Integration Tests
           echo -e "\nRunning MongoDBAtlasODBC.datasource-test.query.pq" &&
           test_output=`tools/PQTest.exe run-test --extension MongoDBAtlasODBC.pqx \
-            --queryFile connector/MongoDBAtlasODBC.datasource-test.query.pq --prettyPrint` &&
+            --queryFile connector/MongoDBAtlasODBC.datasource-test.query.pq --prettyPrint` 
           # Until the SDK is updated (October-November 2023, we can't run these tests)
           # echo "Running MongoDBAtlasODBC.nativequery-test.query.pq" &&
           # test_output+=`tools/PQTest.exe run-test --extension MongoDBAtlasODBC.pqx \
           #   --queryFile connector/MongoDBAtlasODBC.nativequery-test.query.pq --prettyPrint`
           EXITCODE=$?
           echo "$test_output"
-          failures=`echo "$test_output"  | grep Failure -A 1 || true`
           echo $test_output > MongoDBAtlasODBC.integration-test.log
-          if [[ ! -z $failures ]]; then
-            echo "Failures Encountered:"
-            echo $failures
-            if [ "$EXITCODE" -eq "0" ]; then
-              EXITCODE=1
-            fi
+          # Check for "100% success rate" and "All X Passed"
+          if echo "$test_output" | grep -q "100% success rate" && echo "$test_output" | grep -q "All .* Passed"; then
+            echo "All tests passed successfully."
+          else
+            echo "Tests failed or unexpected output. Check the log for details."
+            EXITCODE=1
           fi
 
           # Stop local ADF, always run this to keep task from hanging

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -53,9 +53,16 @@ PATH=$GOBINDIR:$PATH
 # dependencies needed to build it.
 # If unset, it will default to using the SSH private key on the local system.
 if [[ ${GITHUB_TOKEN} ]]; then
+  echo "Using GITHUB_TOKEN for git clone"
+  # Clear git url configurations if they exist
+  git config --global --get-regexp '^url\.' | while read -r key _; do
+      git config --global --unset "$key"
+  done
+
   MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git
-  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/".insteadOf "https://github.com/10gen/"
 else
+  echo "GITHUB_TOKEN is not set, using ssh clone"
   MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
 fi
 
@@ -396,7 +403,6 @@ if [ $ARG = $START ]; then
           MONGOHOUSE_DIR=$LOCAL_INSTALL_DIR/mongohouse
         fi
         # Install and start mongohoused
-        git config --global url.git@github.com:.insteadOf https://github.com/
         # Clone the mongohouse repo
         if [ ! -d "$MONGOHOUSE_DIR" ]; then
             git clone $MONGOHOUSE_URI $MONGOHOUSE_DIR

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -464,7 +464,7 @@ if [ $ARG = $START ]; then
     mkdir -p $LOGS_PATH
     # Start mongohoused with appropriate config
     $GO run -tags mongosql ./cmd/mongohoused/mongohoused.go \
-      --config ./testdata/config/inline_local/frontend-agent-backend.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
+      --config ./testdata/config/inline_local/frontend-agent-backend-resource-manager.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
     echo $! > $TMP_DIR/${MONGOHOUSED}.pid
 
     waitCounter=0

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -64,6 +64,7 @@ if [[ ${GITHUB_TOKEN} ]]; then
 else
   echo "GITHUB_TOKEN is not set, using ssh clone"
   MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
+  git config --global url.git@github.com:.insteadOf https://github.com/
 fi
 
 MACHINE_ARCH=$(uname -m)

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -49,9 +49,18 @@ GO="$GOBINDIR/go"
 
 PATH=$GOBINDIR:$PATH
 
+# GITHUB_TOKEN must be set for cloning 10gen/mongohouse repository from Evergreen hosts, and the
+# dependencies needed to build it.
+# If unset, it will default to using the SSH private key on the local system.
+if [[ ${GITHUB_TOKEN} ]]; then
+  MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+else
+  MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
+fi
+
 MACHINE_ARCH=$(uname -m)
 LOCAL_INSTALL_DIR=$(pwd)/local_adf
-MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
 MONGO_DB_PATH=$LOCAL_INSTALL_DIR/test_db
 LOGS_PATH=$LOCAL_INSTALL_DIR/logs
 DB_CONFIG_PATH=$(pwd)/resources/integration_test/testdata/adf_db_config.json


### PR DESCRIPTION
Copying changes from the [mongo-jdbc-repo](https://github.com/mongodb/mongo-jdbc-driver/pull/283) over. 

Successful run [here](https://spruce.mongodb.com/task/mongo_powerbi_connector_windows_64_integration_test_patch_66fff59a4f9cab8f7c4f26254513dd29f353ee7c_66e85e3e4198dd000733cc63_24_09_16_16_36_29/logs?execution=0).  It isn't a host without ssh keys as the devprod team didn't provide a windows one.  However with the changes in run_adf.sh it should be using the tokens since we are passing in the env variable. 