### PR TITLE
SQL-2848: Update common-test-infra module to use mongodb instead of 10gen

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -23,7 +23,7 @@ timeout:
 
 modules:
   - name: sql-engines-common-test-infra
-    owner: 10gen
+    owner: mongodb
     repo: sql-engines-common-test-infra
     branch: main
     auto_update: true


### PR DESCRIPTION
This PR updates the  `sql-engines-common-test-infra` evergreen module to use the `mongodb` org instead of the `10gen` org since the repo has now been migrated.