### PR TITLE
SQL-2858: Disable adding expansions for integration test

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -164,7 +164,7 @@ functions:
       params:
         env:
           GITHUB_TOKEN: "${github_token}"
-        add_expansions_to_env: true
+        add_expansions_to_env: false
         shell: bash
         working_dir: mongo-powerbi-connector
         script: |


### PR DESCRIPTION
Adding expansions must be affecting the github_token environment variable.  After setting it to false, my test runs have been passing.  
Here's a patch with 5 successful runs:
https://spruce.mongodb.com/task/mongo_powerbi_connector_windows_64_integration_test_patch_72a10888f14e827e3b053382a261cb23d3c7892b_68913a34ba5f2a0007ed1374_25_08_04_22_54_53/logs?execution=4
