### PR TITLE
SQL-3097: Fix PowerBI connector build error

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -40,6 +40,11 @@ functions:
         working_dir: mongo-powerbi-connector
         script: |
           ${prepare_shell}
+          # [SQL-3097] The latest PowerQuery.SdkTools is currently broken. 
+          # It bundles different versions of System.Threading.Tasks.Extensions.dll which causes MakePQX to fail
+          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/System.Threading.Tasks.Extensions.dll
+          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/Mashup/ContainerPrivate/System.Threading.Tasks.Extensions.dll
+
           if $UPDATE_PLUGIN_VERSION; then
             sed -i "s/\[Version = \"0.0.0\"\]/\[Version = \"${RELEASE_VERSION}\"\]/g" \
               connector/MongoDBAtlasODBC.pq

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -33,6 +33,18 @@ include:
     module: sql-engines-common-test-infra
 
 functions:
+  "MakePQX dependency fix":
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: mongo-powerbi-connector
+        script: |
+          ${prepare_shell}
+          # [SQL-3097] The latest PowerQuery.SdkTools is currently broken and has mismatched dependencies, one set used by MakePQX, the other set used by PQTest. 
+          # It bundles different versions of System.Threading.Tasks.Extensions.dll which causes MakePQX to fail
+          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/System.Threading.Tasks.Extensions.dll
+          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/Mashup/ContainerPrivate/System.Threading.Tasks.Extensions.dll
+
   "build connector":
     - command: shell.exec
       params:
@@ -40,11 +52,6 @@ functions:
         working_dir: mongo-powerbi-connector
         script: |
           ${prepare_shell}
-          # [SQL-3097] The latest PowerQuery.SdkTools is currently broken. 
-          # It bundles different versions of System.Threading.Tasks.Extensions.dll which causes MakePQX to fail
-          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/System.Threading.Tasks.Extensions.dll
-          cp tools/Mashup/ADO.NET\ Providers/MashupSql2/System.Threading.Tasks.Extensions.dll tools/Mashup/ContainerPrivate/System.Threading.Tasks.Extensions.dll
-
           if $UPDATE_PLUGIN_VERSION; then
             sed -i "s/\[Version = \"0.0.0\"\]/\[Version = \"${RELEASE_VERSION}\"\]/g" \
               connector/MongoDBAtlasODBC.pq
@@ -386,6 +393,7 @@ pre:
 tasks:
   - name: build
     commands:
+      - func: "MakePQX dependency fix"
       - func: "build connector"
       - func: "upload packaged connector"
 
@@ -407,7 +415,7 @@ tasks:
       - name: integration-test
     commands:
       - func: "fetch packaged connector"
-      - func: "install power query tools"
+      - func: "MakePQX dependency fix"
       - func: "sign connector"
       - func: "upload signed connector"
 


### PR DESCRIPTION
The latest PowerQuery.SdkTools bundles different versions of System.Threading.Tasks.Extensions.dll.
The internal Mashup components reference v4.2.0.1 needed by MakePQX.exe which is bundled in `tools/Mashup/ADO.NET\ Providers/MashupSql2`. Before building, the other bundled version are overwritten with the correct one.